### PR TITLE
Pass barStyle prop to Bar component

### DIFF
--- a/examples/actualComponents/Panel.js
+++ b/examples/actualComponents/Panel.js
@@ -184,6 +184,7 @@ class SwipeablePanel extends Component {
   render() {
     const { showComponent } = this.state;
     const {
+      barStyle,
       noBackgroundOpacity,
       style,
       closeRootStyle,
@@ -218,7 +219,7 @@ class SwipeablePanel extends Component {
             style,
           ]}
           {...this.panResponder.panHandlers}>
-          {!this.props.noBar && <Bar />}
+          {!this.props.noBar && <Bar barStyle={barStyle}/>}
           {this.props.showCloseButton && (
             <Close
               rootStyle={closeRootStyle}


### PR DESCRIPTION
This PR passes `barStyle` down to `Bar` component making it possible to customise Bar styles.